### PR TITLE
predecessor issue fix

### DIFF
--- a/RobotLabDFS/RobotLabDFS.java
+++ b/RobotLabDFS/RobotLabDFS.java
@@ -38,25 +38,22 @@ public class RobotLabDFS {
     Stack<Node> stack = new Stack<Node>();
     stack.push(S);
     
-    do {
+    while(!stack.empty()) {
 	if(currentNode.equals(G)) {
 	    break;
 	} else {
 	    if(currentNode.getChild() == null) {
-	      int i = 0;
-	      int j = 0;
 		currentNode.explored = true;
 		currentNode = currentNode.pred;
-		Node printMe = stack.pop();
-		LCD.drawString(printMe.name, i, j);
-		j++;
+		stack.pop();
 	    }
 	    else {
-	      stack.push(currentNode.getChild());
-	      currentNode = currentNode.getChild();
+		currentNode.getChild().pred = currentNode;
+	      	stack.push(currentNode.getChild());
+	      	currentNode = currentNode.getChild();
 	    }
 	}
-    } while(currentNode.pred != null);
+    }
     
    /* int i = 0;
     int j = 0;


### PR DESCRIPTION
Predecessor of a node is set when a child is added. Since we add B as a child of A after we set B as a child of S, then B's  predecessor is A. So it explores the following way S->B->C->E->C->B->A never travelling back to S, and since we only add childs and never see A as a child of S, A is never added. Simple fix redefine the predecessor as the Node previously travelled from, so when we get to B, S is now it's predecessor. Old condition would cause this to brake, so now checking for empty stack.